### PR TITLE
unpin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=1.5
-Jinja2==2.11.3
-jsonschema==3.2.0
-PyYAML==5.4.1
+sphinx
+Jinja2
+jsonschema
+PyYAML


### PR DESCRIPTION
these dependencies are causing the build for `django-comments-dab` to fail.
Build: https://github.com/Radi85/Comment/runs/6954295186?check_suite_focus=true
Related issue: https://github.com/pallets/jinja/issues/1585